### PR TITLE
Switch numerical tests to numpy allclose

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ conda search sgp4 --channel conda-forge
 ```
 
 
-
 About conda-forge
 =================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
@@ -14,6 +12,8 @@ environment:
   # We set a default Python version for the miniconda that is to be installed. This can be
   # overridden in the matrix definition where appropriate.
   CONDA_PY: "27"
+  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,12 +21,27 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -47,24 +62,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,4 +50,6 @@ about:
 extra:
   recipe-maintainers:
     - jochym
+    - brandon-rhodes
+
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,4 +52,3 @@ extra:
     - jochym
     - brandon-rhodes
 
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,11 @@ source:
   sha256: {{ sha256 }}
   patches:
     - manifest.patch
+    - tests.patch
 
 build:
-  skip: true  # [win64]
-  number: 0
+#  skip: true  # [win64]
+  number: 1
   script: python setup.py install
 
 requirements:
@@ -28,6 +29,8 @@ requirements:
     - python
 
 test:
+  requires:
+    - numpy
   imports:
     - sgp4
     - sgp4.tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,4 +51,3 @@ extra:
   recipe-maintainers:
     - jochym
     - brandon-rhodes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ source:
     - tests.patch
 
 build:
-#  skip: true  # [win64]
   number: 1
   script: python setup.py install
 

--- a/recipe/tests.patch
+++ b/recipe/tests.patch
@@ -1,5 +1,5 @@
 diff --git a/sgp4/tests.py b/sgp4/tests.py
-index 618f786..f2ef91a 100644
+index 618f786..582a104 100644
 --- a/sgp4/tests.py
 +++ b/sgp4/tests.py
 @@ -10,6 +10,7 @@ import re
@@ -10,16 +10,19 @@ index 618f786..f2ef91a 100644
  
  from sgp4.earth_gravity import wgs72
  from sgp4.ext import invjday, newtonnu, rv2coe
-@@ -112,10 +113,10 @@ class Tests(TestCase):
+@@ -112,11 +113,11 @@ class Tests(TestCase):
          # Exercise the newtonnu() code path with asinh() to see whether
          # we can replace it with the one from Python's math module.
  
 -        self.assertEqual(newtonnu(1.0, 2.9),   # parabolic
+-                         (8.238092752965605, 194.60069989482898))
 +        np.testing.assert_allclose(newtonnu(1.0, 2.9),   # parabolic
-                          (8.238092752965605, 194.60069989482898))
++                         (8.238092752965605, 194.60069989482898), rtol=1e-15)
  
 -        self.assertEqual(newtonnu(1.1, 2.7),   # hyperbolic
+-                         (4.262200676156417, 34.76134082028372))
 +        np.testing.assert_allclose(newtonnu(1.1, 2.7),   # hyperbolic
-                          (4.262200676156417, 34.76134082028372))
++                         (4.262200676156417, 34.76134082028372), rtol=1e-15)
  
      def test_good_tle_checksum(self):
+         for line, expected in (good1, 3), (good2, 7):

--- a/recipe/tests.patch
+++ b/recipe/tests.patch
@@ -1,0 +1,25 @@
+diff --git a/sgp4/tests.py b/sgp4/tests.py
+index 618f786..f2ef91a 100644
+--- a/sgp4/tests.py
++++ b/sgp4/tests.py
+@@ -10,6 +10,7 @@ import re
+ import sys
+ from doctest import DocTestSuite, ELLIPSIS
+ from math import pi, isnan
++import numpy as np
+ 
+ from sgp4.earth_gravity import wgs72
+ from sgp4.ext import invjday, newtonnu, rv2coe
+@@ -112,10 +113,10 @@ class Tests(TestCase):
+         # Exercise the newtonnu() code path with asinh() to see whether
+         # we can replace it with the one from Python's math module.
+ 
+-        self.assertEqual(newtonnu(1.0, 2.9),   # parabolic
++        np.testing.assert_allclose(newtonnu(1.0, 2.9),   # parabolic
+                          (8.238092752965605, 194.60069989482898))
+ 
+-        self.assertEqual(newtonnu(1.1, 2.7),   # hyperbolic
++        np.testing.assert_allclose(newtonnu(1.1, 2.7),   # hyperbolic
+                          (4.262200676156417, 34.76134082028372))
+ 
+     def test_good_tle_checksum(self):


### PR DESCRIPTION
Try to prevent meaningless test failures. Exact float comparisons are bound to fail randomly.
Use numpy assert_allclose to run the comparisons.